### PR TITLE
Accepts arguments as valid JSON types separated by comma

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports.templateTags = [{
         if (formatString != "") {
             try {
                 // Attempt to parse arguments as JSON object or list
-                return faker[type][subTypeValue](JSON.parse(formatString));
+                return faker[type][subTypeValue](...JSON.parse(`[${formatString}]`));
             } catch (err) {
                 try {
                     // Attempt to parse as list of arguments


### PR DESCRIPTION
This is probably a breaking change, but it allows more flexibility when passing arguments as modifier
it takes more than one argument, and any JSON valid type is accepted, so for example, for the Finance -> Amount, which takes `(min:number, max:number, dec:number, symbol:string)`, now works with something like `100, 200, 3, "$ "`, which produces something like `$ 144.614`
 
![image](https://user-images.githubusercontent.com/5258081/131687915-15d20f2e-c294-47d9-a07b-7189679046a6.png)
