### PR TITLE
Bump Faker to 5.5.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var faker = require('faker');
-var isEmpty = require('lodash/isEmpty');
-var startCase = require('lodash/startCase');
+var properCase = require('proper-case');
 
 // List of all types of Fakers. We specify this explicitly since there is
 // no easy way to filter out these from the other objects on the faker module.
@@ -31,7 +30,7 @@ var fakerTypes = [
 function populateFakerOptions(someArray) {
   return someArray.sort().map(function(key) {
     return {
-      displayName: startCase(key),
+      displayName: properCase(key),
       value: key,
     };
   });
@@ -43,7 +42,7 @@ function populateFakerSubOptions() {
     var fakerTypeOptions = populateFakerOptions(Object.keys(faker[fakerType]));
 
     return {
-      displayName: startCase(fakerType),
+      displayName: properCase(fakerType),
       type: 'enum',
       defaultValue: '',
       options: fakerTypeOptions,
@@ -89,7 +88,7 @@ module.exports.templateTags = [{
     // Check to see if we have selected a Sub Type Value
     var subTypeValue = args[fakerTypeIndex];
     // If not, be sure to select the first value from the correct Faker Type
-    if (isEmpty(subTypeValue)) {
+    if (subTypeValue === '') {
       subTypeValue = this.args[fakerTypeIndex + 1].options[0].value;
     }
     // Setup faker locale for i18n support
@@ -98,7 +97,7 @@ module.exports.templateTags = [{
     // Optional Format String
     var formatString = args.slice(-2)[0];
 
-    if (!isEmpty(formatString)) {
+    if (!(formatString === '')) {
       try {
         // Attempt to parse arguments as JSON object or list
         return faker[type][subTypeValue](JSON.parse(formatString));

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,40 @@
       "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
       "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
+    "proper-case": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/proper-case/-/proper-case-1.0.5.tgz",
+      "integrity": "sha1-bp5Xc3eZAXNT8eLHD56U5vku/qQ=",
+      "requires": {
+        "title-case": "^2.1.0"
+      }
+    },
+    "title-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
+      }
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/bbbco/insomnia-plugin-faker#readme",
   "dependencies": {
     "faker": "^5.5.3",
-    "lodash": "^4.17.21"
+    "proper-case": "^1.0.5"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
- Bumping faker to `^5.5.3` and replacing `proper-case` with `lodash/startCase` with Lodash at `^4.17.21`.
- Made some updates to logic checks
- Resolved discrepancies between syntax styles by moving everything to older JS syntax to match the majority of the code
- Changed anonymous functions to named functions

The reason for making this PR is I was experiencing problems giving `faker.random.number()` an optional JSON argument in Insomnia (it would display something exactly like what is shown in #8 & #7 .

I am now not seeing the error with the new `faker.datatype.number()` and values are as expected.